### PR TITLE
fix(costumes): cast rotation center coords to int for PIL paste

### DIFF
--- a/src/sb2gs/costumes.py
+++ b/src/sb2gs/costumes.py
@@ -45,7 +45,7 @@ def fix_bitmap_center(costume: JSONObject, path: Path) -> None:
     ):
         return
     fixed = Image.new("RGBA", (960, 720), (0, 0, 0, 0))
-    fixed.paste(img, (480 - costume.rotationCenterX, 360 - costume.rotationCenterY))
+    fixed.paste(img, (int(480 - costume.rotationCenterX), int(360 - costume.rotationCenterY)))
     fixed.save(path, format=costume.dataFormat)
 
 


### PR DESCRIPTION
Fixes #21

## Problem
`costume.rotationCenterX` / `rotationCenterY` can be floats, but `PIL.Image.paste()` requires integer coordinates, causing a `TypeError` during bitmap costume processing.

## Solution
Cast the coordinates to `int` before passing them to `PIL.Image.paste()`.